### PR TITLE
rpath stack fix

### DIFF
--- a/BaseBin/systemhook/src/main.c
+++ b/BaseBin/systemhook/src/main.c
@@ -222,7 +222,9 @@ void* dlopen_hook(const char* path, int mode)
 	if (path) {
 		jbdswProcessLibrary(path);
 	}
-	return dlopen(path, mode);
+	
+	void* callerAddress = __builtin_return_address(0);
+    return dlopen_from(path, mode, callerAddress);
 }
 
 void* dlopen_from_hook(const char* path, int mode, void* addressInCaller)


### PR DESCRIPTION
dyld need the caller address for handing rpath stack

<img width="492" alt="image" src="https://user-images.githubusercontent.com/103268705/233660586-803ed1b9-5c57-4e08-a795-d4538d6a3611.png">

<img width="812" alt="image" src="https://user-images.githubusercontent.com/103268705/233660497-a968a8af-8c0b-495d-8cd3-c4170c324ae7.png">

