### PR TITLE
Make iDownload Switch more clear to user

### DIFF
--- a/Dopamine/ar.lproj/Localizable.strings
+++ b/Dopamine/ar.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "إعادة تشغيل واجهة النظام";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (محطة المطور)";
 
 "Settings_Tweak_Injection" = "وصول الأدوات";
 

--- a/Dopamine/da.lproj/Localizable.strings
+++ b/Dopamine/da.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "Genstart SpringBoard";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Udviklerterminal)";
 
 "Settings_Tweak_Injection" = "Tweak-injektion";
 

--- a/Dopamine/de.lproj/Localizable.strings
+++ b/Dopamine/de.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "SpringBoard neustarten";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Entwickler-Terminal)";
 
 "Settings_Tweak_Injection" = "Tweaks laden";
 

--- a/Dopamine/el.lproj/Localizable.strings
+++ b/Dopamine/el.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "Επανεκκίνηση SpringBoard";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Τερματικό προγραμματιστή)";
 
 "Settings_Tweak_Injection" = "Ενσωμάτωση Tweak";
 

--- a/Dopamine/en.lproj/Localizable.strings
+++ b/Dopamine/en.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "Restart SpringBoard";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Developer Shell)";
 
 "Settings_Tweak_Injection" = "Tweak Injection";
 

--- a/Dopamine/fil.lproj/Localizable.strings
+++ b/Dopamine/fil.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "Restart SpringBoard";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Terminal ng Developer)";
 
 "Settings_Tweak_Injection" = "Tweak Injection";
 

--- a/Dopamine/fr.lproj/Localizable.strings
+++ b/Dopamine/fr.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "Redémarrer la SpringBoard";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Terminal du développeur)";
 
 "Settings_Tweak_Injection" = "Injection de Tweak";
 

--- a/Dopamine/ja.lproj/Localizable.strings
+++ b/Dopamine/ja.lproj/Localizable.strings
@@ -186,7 +186,7 @@
 "Settings_Verbose_Logs" = "詳細なログ";
 
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (デベロッパー端末)";
 
 
 "Starting Launch Daemons" = "Launch Daemonを開始中";

--- a/Dopamine/kk.lproj/Localizable.strings
+++ b/Dopamine/kk.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "SpringBoard қайта іске қосу";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Әзірлеуші ​​​​терминалы)";
 
 "Settings_Tweak_Injection" = "Твиктерді енгізу";
 

--- a/Dopamine/ko.lproj/Localizable.strings
+++ b/Dopamine/ko.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "SpringBoard 재시작";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (개발자 터미널)";
 
 "Settings_Tweak_Injection" = "트윅 추가";
 

--- a/Dopamine/nl.lproj/Localizable.strings
+++ b/Dopamine/nl.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "SpringBoard herstarten";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Ontwikkelaar Terminal)";
 
 "Settings_Tweak_Injection" = "Tweak Injection";
 

--- a/Dopamine/pl.lproj/Localizable.strings
+++ b/Dopamine/pl.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "Restartuj SpringBoard";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Terminal dla deweloperów)";
 
 "Settings_Tweak_Injection" = "Tweak Injection";
 

--- a/Dopamine/pt-BR.lproj/Localizable.strings
+++ b/Dopamine/pt-BR.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "Reiniciar a SpringBoard";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Terminal do desenvolvedor)";
 
 "Settings_Tweak_Injection" = "Injeção de Tweaks";
 

--- a/Dopamine/ru.lproj/Localizable.strings
+++ b/Dopamine/ru.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "Перезапустить SpringBoard";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Терминал разработчика)";
 
 "Settings_Tweak_Injection" = "Внедрение твиков";
 

--- a/Dopamine/sv.lproj/Localizable.strings
+++ b/Dopamine/sv.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "Starta om SpringBoard";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Terminal för utvecklare)";
 
 "Settings_Tweak_Injection" = "Tweak Injection";
 

--- a/Dopamine/tr.lproj/Localizable.strings
+++ b/Dopamine/tr.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "Springboard'u Yeniden Başlat";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Geliştirici Terminali)";
 
 "Settings_Tweak_Injection" = "Tweak Enjeksiyonu";
 

--- a/Dopamine/uk.lproj/Localizable.strings
+++ b/Dopamine/uk.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "Перезапустити SpringBoard";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (Термінал розробника)";
 
 "Settings_Tweak_Injection" = "ін'єкція твiков";
 

--- a/Dopamine/ur.lproj/Localizable.strings
+++ b/Dopamine/ur.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "اسپرنگ بورڈ کو دوبارہ شروع کریں";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (ڈویلپر ٹرمینل)";
 
 "Settings_Tweak_Injection" = "Tweak Injection";
 

--- a/Dopamine/vi.lproj/Localizable.strings
+++ b/Dopamine/vi.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "Khởi động lại SpringBoard";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (nhà phát triển)";
 
 "Settings_Tweak_Injection" = "Bật Tweak Injection";
 

--- a/Dopamine/zh-Hans.lproj/Localizable.strings
+++ b/Dopamine/zh-Hans.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "重启SpringBoard";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (开发商终端)";
 
 "Settings_Tweak_Injection" = "插件注入";
 

--- a/Dopamine/zh_HK.lproj/Localizable.strings
+++ b/Dopamine/zh_HK.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "註銷";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (开发商终端)";
 
 "Settings_Tweak_Injection" = "插件注入";
 

--- a/Dopamine/zh_TW.lproj/Localizable.strings
+++ b/Dopamine/zh_TW.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 
 "Menu_Restart_SpringBoard_Title" = "重新啟動主畫面";
 
-"Settings_iDownload" = "iDownload";
+"Settings_iDownload" = "iDownload (开发商终端)";
 
 "Settings_Tweak_Injection" = "外掛注入";
 


### PR DESCRIPTION
Make iDownload Switch more clear to user
`iDownload` is now -> `iDownload (Developer Shell)`