### PR TITLE
refreshAppRegistrations before OTA

### DIFF
--- a/BaseBin/jailbreakd/src/update.m
+++ b/BaseBin/jailbreakd/src/update.m
@@ -182,6 +182,8 @@ int jbUpdateFromTIPA(NSString *tipaPath, bool rebootWhenDone)
 {
 	NSString *tsRootHelperPath = trollStoreRootHelperPath();
 	if (!tsRootHelperPath) return 1;
+	spawn(tsRootHelperPath, @[@"refresh"]);
+	sleep(2);
 	int installRet = spawn(tsRootHelperPath, @[@"install", tipaPath]);
 	if (installRet != 0) return 2;
 


### PR DESCRIPTION
When the trollstore drops the signature, the OTA will fail. 
The system freezes and can only be forced to restart