### PR TITLE
Add Wi-Fi check

### DIFF
--- a/Dopamine/Dopamine/UI/Views/Jailbreak.swift
+++ b/Dopamine/Dopamine/UI/Views/Jailbreak.swift
@@ -10,6 +10,7 @@ import Fugu15KernelExploit
 import CBindings
 
 var fakeRootPath: String? = nil
+var wifiEnabled: Bool = false
 public func rootifyPath(path: String) -> String? {
     if fakeRootPath == nil {
         fakeRootPath = Bootstrapper.locateExistingFakeRoot()
@@ -83,6 +84,7 @@ func jailbreak(completion: @escaping (Error?) -> ()) {
         }
         else {
             if wifiIsEnabled() {
+                wifiEnabled = true
                 setWifiEnabled(false)
                 Logger.log("Disabling Wi-Fi", isStatus: true)
                 sleep(5)
@@ -110,8 +112,10 @@ func jailbreak(completion: @escaping (Error?) -> ()) {
             // No Wifi fixup needed
         }
         else {
-            setWifiEnabled(true)
-            Logger.log("Enabling Wi-Fi", isStatus: true)
+            if wifiEnabled {
+                setWifiEnabled(true)
+                Logger.log("Enabling Wi-Fi", isStatus: true)
+            }
         }
         
         try Fugu15.startEnvironment()


### PR DESCRIPTION
This PR ensures Wi-Fi is not re-enabled if it wasn't on in the first place. All that's in here is a new variable + a quick check at the end of the jailbreaking process.
Tested on an iPhone 13 on iOS 15.1.1, works as intended.