### PR TITLE
Disable RemoveJailbreak when Jailbroken.

### DIFF
--- a/Dopamine/Dopamine/UI/Views/SettingsView.swift
+++ b/Dopamine/Dopamine/UI/Views/SettingsView.swift
@@ -120,23 +120,25 @@ struct SettingsView: View {
                                                 .stroke(Color.white.opacity(0.25), lineWidth: 0.5)
                                         )
                                     }
-                                    Button(action: {
-                                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                                        removeJailbreakAlertShown = true
-                                    }) {
-                                        HStack {
-                                            Image(systemName: "trash")
-                                            Text("Button_Remove_Jailbreak")
-                                                .lineLimit(1)
-                                                .minimumScaleFactor(0.5)
+                                    if !isJailbroken() {
+                                        Button(action: {
+                                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                                            removeJailbreakAlertShown = true
+                                        }) {
+                                            HStack {
+                                                Image(systemName: "trash")
+                                                Text("Button_Remove_Jailbreak")
+                                                    .lineLimit(1)
+                                                    .minimumScaleFactor(0.5)
+                                            }
+                                            .padding(.horizontal, 4)
+                                            .padding(8)
+                                            .frame(maxWidth: .infinity)
+                                            .overlay(
+                                                RoundedRectangle(cornerRadius: 8)
+                                                    .stroke(Color.white.opacity(0.25), lineWidth: 0.5)
+                                            )
                                         }
-                                        .padding(.horizontal, 4)
-                                        .padding(8)
-                                        .frame(maxWidth: .infinity)
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: 8)
-                                                .stroke(Color.white.opacity(0.25), lineWidth: 0.5)
-                                        )
                                     }
                                     Text(isJailbroken() ? "Hint_Hide_Jailbreak_Jailbroken" : "Hint_Hide_Jailbreak")
                                         .font(.footnote)


### PR DESCRIPTION
Basically, the function to remove jailbreak will mount the volume containing the `preboot` path as readable and then delete the `jb-xxxxxx` directory created by Dopamine. However, directly deleting this directory while the device is in a jailbroken state may cause errors in many running tweaks, leading to system crashes and reboots. Once these conditions occur, the state of the `jb-xxxxxx` directory becomes unpredictable since the deletion process is not atomic.

Therefore, I am considering making the function to remove jailbreak available only in a non-jailbroken state. - This approach follows the example set by the unc0ver jailbreak tool.