### PR TITLE
Fix zh_CN/TW/Hans locales

### DIFF
--- a/Application/Dopamine/zh-CN.lproj/Localizable.strings
+++ b/Application/Dopamine/zh-CN.lproj/Localizable.strings
@@ -11,8 +11,8 @@
 
 // Action Menu
 "Menu_Settings_Title" = "设置";
-"Menu_Restart_SpringBoard_Title" = "注销";
-"Menu_Reboot_Userspace_Title" = "重启用户空间";
+"Menu_Restart_SpringBoard_Title" = "重新启动SpringBoard";
+"Menu_Reboot_Userspace_Title" = "重新启动用户空间";
 "Menu_Credits_Title" = "关于";
 
 // Updating
@@ -58,8 +58,8 @@
 "Section_Exploits" = "漏洞利用";
 
 // Settings Alerts
-"Alert_Tweak_Injection_Toggled_Title" = "需要重启用户空间";
-"Alert_Tweak_Injection_Toggled_Body" = "需要重启用户空间才能应用变更，立即执行？";
+"Alert_Tweak_Injection_Toggled_Title" = "需要重新启动用户空间";
+"Alert_Tweak_Injection_Toggled_Body" = "需要重新启动用户空间才能应用变更，立即执行？";
 "Alert_Tweak_Injection_Toggled_Reboot_Now" = "重新启动";
 "Alert_Tweak_Injection_Toggled_Reboot_Later" = "以后";
 "Alert_Remove_Jailbreak_Title" = "移除越狱";
@@ -92,7 +92,7 @@
 "Elevating Privileges" = "提升权限";
 "Cleaning Up Exploits" = "清理环境";
 "Building Phys R/W Primitive" = "构建硬件读写条件";
-"Rebooting Userspace" = "重启用户空间";
+"Rebooting Userspace" = "重新启动用户空间";
 "Patchfinding" = "查找地址";
 "Exploiting Kernel (%@)" = "利用内核漏洞 (%@)";
 "Bypassing PAC (%@)" = "正在绕过 PAC (%@)";
@@ -102,4 +102,3 @@
 "Status_Title_Select_Package_Managers" = "选择包管理器";
 "Select_Package_Managers_Install_Message" = "若不确定如何选择，请使用 Sileo";
 "Continue" = "继续";
-

--- a/Application/Dopamine/zh-Hans.lproj/Localizable.strings
+++ b/Application/Dopamine/zh-Hans.lproj/Localizable.strings
@@ -11,8 +11,8 @@
 
 // Action Menu
 "Menu_Settings_Title" = "设置";
-"Menu_Restart_SpringBoard_Title" = "注销";
-"Menu_Reboot_Userspace_Title" = "重启用户空间";
+"Menu_Restart_SpringBoard_Title" = "重新启动SpringBoard";
+"Menu_Reboot_Userspace_Title" = "重新启动用户空间";
 "Menu_Credits_Title" = "关于";
 
 // Updating
@@ -58,8 +58,8 @@
 "Section_Exploits" = "漏洞利用";
 
 // Settings Alerts
-"Alert_Tweak_Injection_Toggled_Title" = "需要重启用户空间";
-"Alert_Tweak_Injection_Toggled_Body" = "需要重启用户空间才能应用变更，立即执行？";
+"Alert_Tweak_Injection_Toggled_Title" = "需要重新启动用户空间";
+"Alert_Tweak_Injection_Toggled_Body" = "需要重新启动用户空间才能应用变更，立即执行？";
 "Alert_Tweak_Injection_Toggled_Reboot_Now" = "重新启动";
 "Alert_Tweak_Injection_Toggled_Reboot_Later" = "以后";
 "Alert_Remove_Jailbreak_Title" = "移除越狱";
@@ -92,7 +92,7 @@
 "Elevating Privileges" = "提升权限";
 "Cleaning Up Exploits" = "清理环境";
 "Building Phys R/W Primitive" = "构建硬件读写条件";
-"Rebooting Userspace" = "重启用户空间";
+"Rebooting Userspace" = "重新启动用户空间";
 "Patchfinding" = "查找地址";
 "Exploiting Kernel (%@)" = "利用内核漏洞 (%@)";
 "Bypassing PAC (%@)" = "正在绕过 PAC (%@)";

--- a/Application/Dopamine/zh-TW.lproj/Localizable.strings
+++ b/Application/Dopamine/zh-TW.lproj/Localizable.strings
@@ -12,7 +12,7 @@
 // Action Menu
 "Menu_Settings_Title" = "設定";
 "Menu_Restart_SpringBoard_Title" = "重新啟動主畫面";
-"Menu_Reboot_Userspace_Title" = "重啟使用者空間";
+"Menu_Reboot_Userspace_Title" = "重新啟動使用者空間";
 "Menu_Credits_Title" = "致謝";
 
 // Updating
@@ -59,7 +59,7 @@
 
 // Settings Alerts
 /*Alert_Tweak_Injection_Toggled_Title*/
-"Alert_Tweak_Injection_Toggled_Body" = "即將重啟使用者空間是否繼續？";
+"Alert_Tweak_Injection_Toggled_Body" = "即將重新啟動使用者空間是否繼續？";
 /*Alert_Tweak_Injection_Toggled_Reboot_Now*/
 /*Alert_Tweak_Injection_Toggled_Reboot_Later*/
 "Alert_Remove_Jailbreak_Title" = "移除越獄";


### PR DESCRIPTION
Someone tampered with the translation and his mistranslation was merged. Please don't merge @xybp888's mistranslation if he tampers again.

1. "Restart SpringBoard"不应该被翻译为 "注销"，"注销"应该对应"deregister" or "logout"；
2. "restart"应为"重新启动"，因为在iOS系统中是这样翻译的。

Response to the discussion on whether Restart Springboard should be translated as "重新启动Springboard" or "注销".

> “注销”一词无论是在现代汉语大词典中的原解释，还是在计算机领域的引申含义，都只有“关闭”“取消”的单向的意思，而在这里Dopamine显然不止关闭了，还开启了Springboard。先关闭，然后再开启，最好的翻译当然是“重新启动”。
> 
> The word "注销", both in its original interpretation in the Modern Chinese Dictionary and in its derivation in the computer field, only means "to shut down" or "to cancel", whereas here Dopamine apparently not only shuts down but also turns on Springboard. In this case, Dopamine apparently not only turned off, but also turned on Springboard, first turning it off, then turning it on again, which is best translated as "重新启动Springboard".
> 
> ![1C16EB30-23A1-4BCC-983E-F2EF05362DD3](https://github.com/opa334/Dopamine/assets/86581525/d0f8ac0a-9dfb-4ae5-80a5-58da954c5111)
