### PR TITLE
Fix proc offsets for iOS 16.4 beta 1-3

### DIFF
--- a/BaseBin/libjailbreak/src/info.c
+++ b/BaseBin/libjailbreak/src/info.c
@@ -227,11 +227,15 @@ void jbinfo_initialize_hardcoded_offsets(void)
 						if (strcmp(xnuVersion, "22.3.0") >= 0) { // iOS 16.3+
 							gSystemInfo.kernelConstant.smrBase = 2;
 							if (strcmp(xnuVersion, "22.4.0") >= 0) { // iOS 16.4+
+								// proc
+								gSystemInfo.kernelStruct.proc.flag   = 0x454;
+								gSystemInfo.kernelStruct.proc.textvp = 0x548;
+
 								if (strcmp(xnuVersion, "22.4.0") == 0) { // iOS 16.4 ONLY 
 									// iOS 16.4 beta 1-3 use the old proc struct, 16.4b4+ use new
-									if (gSystemInfo.kernelStruct.proc.struct_size != 0x538) {
-										gSystemInfo.kernelStruct.proc.flag   = 0x454;
-										gSystemInfo.kernelStruct.proc.textvp = 0x548;
+									if (gSystemInfo.kernelStruct.proc.struct_size != 0x730) {
+										gSystemInfo.kernelStruct.proc.flag    = 0x25C;
+										gSystemInfo.kernelStruct.proc.textvp  = 0x350;
 									}
 								}
 							}

--- a/BaseBin/libjailbreak/src/info.c
+++ b/BaseBin/libjailbreak/src/info.c
@@ -227,9 +227,11 @@ void jbinfo_initialize_hardcoded_offsets(void)
 						if (strcmp(xnuVersion, "22.3.0") >= 0) { // iOS 16.3+
 							gSystemInfo.kernelConstant.smdBase = 2;
 							if (strcmp(xnuVersion, "22.4.0") >= 0) { // iOS 16.4+
-								// proc
-								gSystemInfo.kernelStruct.proc.flag   = 0x454;
-								gSystemInfo.kernelStruct.proc.textvp = 0x548;
+								// iOS 16.4 beta 1-3 use the old proc_struct, 16.4b4+ use new
+								if (gSystemInfo.kernelStruct.proc.struct_size != 0x538) {
+									gSystemInfo.kernelStruct.proc.flag   = 0x454;
+									gSystemInfo.kernelStruct.proc.textvp = 0x548;
+								}
 							}
 						}
 					}

--- a/BaseBin/libjailbreak/src/info.c
+++ b/BaseBin/libjailbreak/src/info.c
@@ -67,7 +67,7 @@ void jbinfo_initialize_hardcoded_offsets(void)
 
 	// ipc_space
 	gSystemInfo.kernelStruct.ipc_space.table          = 0x20;
-	gSystemInfo.kernelStruct.ipc_space.table_uses_smd = false;
+	gSystemInfo.kernelStruct.ipc_space.table_uses_smr = false;
 
 	// ipc_entry
 	gSystemInfo.kernelStruct.ipc_entry.object      = 0x0;
@@ -178,7 +178,7 @@ void jbinfo_initialize_hardcoded_offsets(void)
 				gSystemInfo.kernelStruct.ipc_port.kobject = 0x48;
 
 				if (strcmp(xnuVersion, "22.0.0") >= 0) { // iOS 16+
-					gSystemInfo.kernelConstant.smdBase = 3;
+					gSystemInfo.kernelConstant.smrBase = 3;
 
 					// proc
 					gSystemInfo.kernelStruct.proc.task    =   0x0; // Removed, task is now at (proc + sizeof(proc))
@@ -223,9 +223,9 @@ void jbinfo_initialize_hardcoded_offsets(void)
 #endif
 
 					if (strcmp(xnuVersion, "22.1.0") >= 0) { // iOS 16.1+
-						gSystemInfo.kernelStruct.ipc_space.table_uses_smd = true;
+						gSystemInfo.kernelStruct.ipc_space.table_uses_smr = true;
 						if (strcmp(xnuVersion, "22.3.0") >= 0) { // iOS 16.3+
-							gSystemInfo.kernelConstant.smdBase = 2;
+							gSystemInfo.kernelConstant.smrBase = 2;
 							if (strcmp(xnuVersion, "22.4.0") >= 0) { // iOS 16.4+
 								// iOS 16.4 beta 1-3 use the old proc_struct, 16.4b4+ use new
 								if (gSystemInfo.kernelStruct.proc.struct_size != 0x538) {

--- a/BaseBin/libjailbreak/src/info.c
+++ b/BaseBin/libjailbreak/src/info.c
@@ -227,10 +227,12 @@ void jbinfo_initialize_hardcoded_offsets(void)
 						if (strcmp(xnuVersion, "22.3.0") >= 0) { // iOS 16.3+
 							gSystemInfo.kernelConstant.smrBase = 2;
 							if (strcmp(xnuVersion, "22.4.0") >= 0) { // iOS 16.4+
-								// iOS 16.4 beta 1-3 use the old proc_struct, 16.4b4+ use new
-								if (gSystemInfo.kernelStruct.proc.struct_size != 0x538) {
-									gSystemInfo.kernelStruct.proc.flag   = 0x454;
-									gSystemInfo.kernelStruct.proc.textvp = 0x548;
+								if (strcmp(xnuVersion, "22.4.0") == 0) { // iOS 16.4 ONLY 
+									// iOS 16.4 beta 1-3 use the old proc struct, 16.4b4+ use new
+									if (gSystemInfo.kernelStruct.proc.struct_size != 0x538) {
+										gSystemInfo.kernelStruct.proc.flag   = 0x454;
+										gSystemInfo.kernelStruct.proc.textvp = 0x548;
+									}
 								}
 							}
 						}

--- a/BaseBin/libjailbreak/src/info.h
+++ b/BaseBin/libjailbreak/src/info.h
@@ -21,7 +21,7 @@ struct system_info {
 		uint64_t pointer_mask;
 		uint64_t T1SZ_BOOT;
 		uint64_t ARM_TT_L1_INDEX_MASK;
-		uint64_t smdBase;
+		uint64_t smrBase;
 		uint64_t PT_INDEX_MAX;
 		uint64_t nsysent;
 		uint64_t mach_trap_count;
@@ -145,7 +145,7 @@ struct system_info {
 
 		struct {
 			uint32_t table;
-			bool table_uses_smd;
+			bool table_uses_smr;
 		} ipc_space;
 
 		struct {
@@ -219,7 +219,7 @@ extern struct system_info gSystemInfo;
     iterator(ctx, kernelConstant.pointer_mask); \
     iterator(ctx, kernelConstant.T1SZ_BOOT); \
     iterator(ctx, kernelConstant.ARM_TT_L1_INDEX_MASK); \
-    iterator(ctx, kernelConstant.smdBase); \
+    iterator(ctx, kernelConstant.smrBase); \
     iterator(ctx, kernelConstant.PT_INDEX_MAX); \
     iterator(ctx, kernelConstant.nsysent); \
     iterator(ctx, kernelConstant.mach_trap_count);
@@ -323,7 +323,7 @@ extern struct system_info gSystemInfo;
     iterator(ctx, kernelStruct.thread.machine_contextData); \
 	\
     iterator(ctx, kernelStruct.ipc_space.table); \
-    iterator(ctx, kernelStruct.ipc_space.table_uses_smd); \
+    iterator(ctx, kernelStruct.ipc_space.table_uses_smr); \
 	\
     iterator(ctx, kernelStruct.ipc_entry.object); \
     iterator(ctx, kernelStruct.ipc_entry.struct_size); \

--- a/BaseBin/libjailbreak/src/kernel.c
+++ b/BaseBin/libjailbreak/src/kernel.c
@@ -89,8 +89,8 @@ uint64_t ipc_entry_lookup(uint64_t space, mach_port_name_t name)
 {
 	uint64_t table = 0;
 	// New format in iOS 16.1
-	if (gSystemInfo.kernelStruct.ipc_space.table_uses_smd) {
-		table = kread_smdptr(space + koffsetof(ipc_space, table));
+	if (gSystemInfo.kernelStruct.ipc_space.table_uses_smr) {
+		table = kread_smrptr(space + koffsetof(ipc_space, table));
 	}
 	else {
 		table = kread_ptr(space + koffsetof(ipc_space, table));

--- a/BaseBin/libjailbreak/src/primitives.c
+++ b/BaseBin/libjailbreak/src/primitives.c
@@ -216,7 +216,6 @@ uint64_t kread_ptr(uint64_t va)
 	return UNSIGN_PTR(kread64(va));
 }
 
-// Fuck is an smr ptr??? (I know one thing that it could mean)
 uint64_t kread_smrptr(uint64_t va)
 {
 	uint64_t value = kread_ptr(va);

--- a/BaseBin/libjailbreak/src/primitives.c
+++ b/BaseBin/libjailbreak/src/primitives.c
@@ -216,12 +216,12 @@ uint64_t kread_ptr(uint64_t va)
 	return UNSIGN_PTR(kread64(va));
 }
 
-// Fuck is an smd ptr??? (I know one thing that it could mean)
-uint64_t kread_smdptr(uint64_t va)
+// Fuck is an smr ptr??? (I know one thing that it could mean)
+uint64_t kread_smrptr(uint64_t va)
 {
 	uint64_t value = kread_ptr(va);
 
-	uint64_t bits = (kconstant(smdBase) << (62-kconstant(T1SZ_BOOT)));
+	uint64_t bits = (kconstant(smrBase) << (62-kconstant(T1SZ_BOOT)));
 
 	uint64_t case1 = 0xFFFFFFFFFFFFC000 & ~bits;
 	uint64_t case2 = 0xFFFFFFFFFFFFFFE0 & ~bits;

--- a/BaseBin/libjailbreak/src/primitives.h
+++ b/BaseBin/libjailbreak/src/primitives.h
@@ -38,7 +38,7 @@ int physwrite8(uint64_t pa, uint8_t v);
 
 uint64_t kread64(uint64_t va);
 uint64_t kread_ptr(uint64_t va);
-uint64_t kread_smdptr(uint64_t va);
+uint64_t kread_smrptr(uint64_t va);
 uint32_t kread32(uint64_t va);
 uint16_t kread16(uint64_t va);
 uint8_t kread8(uint64_t va);


### PR DESCRIPTION
Fix proc offsets for iOS 16.4 beta 1-3, and change smd to smr