### PR TITLE
Remove puaf_smith option on 15.x

### DIFF
--- a/Application/Dopamine/Exploits/kfd/Info.plist
+++ b/Application/Dopamine/Exploits/kfd/Info.plist
@@ -54,12 +54,6 @@
 			<array>
 				<dict>
 					<key>Start</key>
-					<string>15.0</string>
-					<key>End</key>
-					<string>15.7.6</string>
-				</dict>
-				<dict>
-					<key>Start</key>
 					<string>16.0</string>
 					<key>End</key>
 					<string>16.5</string>


### PR DESCRIPTION
puaf_smith is currently completely broken on iOS 15.

While fixing it would probably be a better solution on paper, puaf_smith is extremely difficult to troubleshoot, not to mention better exploits exist for 15.x (puaf_physpuppet for 15.0-15.7.3, and puaf_landa for 15.7.4-15.8.1), making any efforts to fix it have almost zero value.