### PR TITLE
multicast_bytecopy for iPad mini 6

### DIFF
--- a/Application/Dopamine/Exploits/multicast_bytecopy/exploit/IOGPU.c
+++ b/Application/Dopamine/Exploits/multicast_bytecopy/exploit/IOGPU.c
@@ -56,11 +56,13 @@ int IOGPU_get_command_queue_extra_refills_needed(void)
     // iPhone 11
     // iPhone 12
     // iPhone 13
+    // iPad mini 6
     if (
        strstr(u.machine, "iPhone9,")
     || strstr(u.machine, "iPhone12,")
     || strstr(u.machine, "iPhone13,")
     || strstr(u.machine, "iPhone14,")
+    || strstr(u.machine, "iPad14,")
     )
     {
         return 1;


### PR DESCRIPTION
add value of IOGPU_get_command_queue_extra_refills_needed for iPad mini 6