### PR TITLE
Enable iOS 16.7.16 Support on arm64

### DIFF
--- a/Application/Dopamine/Exploits/DarkSword/Info.plist
+++ b/Application/Dopamine/Exploits/DarkSword/Info.plist
@@ -21,7 +21,7 @@
 			<array>
 				<dict>
 					<key>End</key>
-					<string>16.7.15</string>
+					<string>16.7.16</string>
 					<key>Start</key>
 					<string>15.0</string>
 				</dict>

--- a/Application/Dopamine/Jailbreak/DOEnvironmentManager.m
+++ b/Application/Dopamine/Jailbreak/DOEnvironmentManager.m
@@ -212,7 +212,7 @@ int reboot3(uint64_t flags, ...);
         return @"iOS 15.0 - 16.5.1 (arm64e)";
     }
     else {
-        return @"iOS 15.0 - 16.7.15 (arm64)";
+        return @"iOS 15.0 - 16.7.16 (arm64)";
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Dopamine
 
-A rootless semi-untethered jailbreak for iOS 15.0 - 16.5.1 (arm64e) and iOS 15.0 - 16.7.15 (arm64). More details will follow here soon.
+A rootless semi-untethered jailbreak for iOS 15.0 - 16.5.1 (arm64e) and iOS 15.0 - 16.7.16 (arm64). More details will follow here soon.
 
 Please note that all issues related to version support will be deleted without response.
 


### PR DESCRIPTION
Screenshot showing Dopamine running with darksword on iPhone 8+ 16.7.16
<img width="1242" height="2208" alt="image" src="https://github.com/user-attachments/assets/06f8afee-13cb-4938-90bb-8d3a6a4692bb" />
