### PR TITLE
Exclude iPad 5th/6th Generation and iPad Pro 9.7" from DarkSword kernel exploit

### DIFF
--- a/Application/Dopamine/Exploits/DarkSword/Info.plist
+++ b/Application/Dopamine/Exploits/DarkSword/Info.plist
@@ -14,6 +14,12 @@
 					<key>Devices</key>
 					<array>
 						<string>A8</string>
+						<string>iPad6,3</string>
+						<string>iPad6,4</string>
+						<string>iPad6,11</string>
+						<string>iPad6,12</string>
+						<string>iPad7,5</string>
+						<string>iPad7,6</string>
 					</array>
 				</dict>
 			</array>


### PR DESCRIPTION
The DarkSword kernel exploit has been observed to *never work* on the 2GB A9(X)/A10 iPads, regardless of iOS version. (I will personally pay anyone $20 (USD) if they have it working on any of the aforementioned devices using any current public Dopamine 2.5 beta version).

As - based on my knowledge - the odds of this issue being resolved anytime in the (near) future are low, we should probably just block these devices from using the DarkSword kernel exploit (required for 16.7+ on these devices), rather than having unknowing users waste their time on something that will literally not work.

Mitigates (though does not resolve) #783, #791, #823, #824, #850. This additionally _does not_ include a case where a very very small % of 6S(+)/SE1 devices also have this type of issue.