### PR TITLE
Enable 26.1b1-3 support

### DIFF
--- a/Application/Dopamine/Exploits/ClearSword/Info.plist
+++ b/Application/Dopamine/Exploits/ClearSword/Info.plist
@@ -11,6 +11,16 @@
 			<key>DPSupportInclude</key>
 			<array>
 				<dict>
+					<key>Builds</key>
+					<array>
+						<string>23B5044l</string>
+						<string>23B5059e</string>
+						<string>23B5064e</string>
+					</array>
+				</dict>
+			</array>
+			<array>
+				<dict>
 					<key>Versions</key>
 					<array>
 						<string>26.0</string>

--- a/Application/Dopamine/Exploits/ClearSword/Info.plist
+++ b/Application/Dopamine/Exploits/ClearSword/Info.plist
@@ -18,8 +18,6 @@
 						<string>23B5064e</string>
 					</array>
 				</dict>
-			</array>
-			<array>
 				<dict>
 					<key>Versions</key>
 					<array>

--- a/Application/Dopamine/Exploits/DarkSword/Info.plist
+++ b/Application/Dopamine/Exploits/DarkSword/Info.plist
@@ -11,6 +11,14 @@
 			<key>DPSupportInclude</key>
 			<array>
 				<dict>
+					<key>Builds</key>
+					<array>
+						<string>23B5044l</string>
+						<string>23B5059e</string>
+						<string>23B5064e</string>
+					</array>
+				</dict>
+				<dict>
 					<key>Versions</key>
 					<array>
 						<string>26.0</string>

--- a/Application/Dopamine/Exploits/momentarius/Info.plist
+++ b/Application/Dopamine/Exploits/momentarius/Info.plist
@@ -13,6 +13,17 @@
 				<string>A12</string>
 				<string>A13</string>
 			</array>
+			<key>DPSupportInclude</key>
+			<array>
+				<dict>
+					<key>Builds</key>
+					<array>
+						<string>23B5044l</string>
+						<string>23B5059e</string>
+						<string>23B5064e</string>
+					</array>
+				</dict>
+			</array>
 			<key>DPSupportedRanges</key>
 			<array>
 				<dict>


### PR DESCRIPTION
These builds appear to have been accidentally omitted from the info.plist in Dopamine 3.0. This resolves the issue and adds these betas so support _actually_ is available as intended.