### PR TITLE
Change bundleid back to Dopamine

### DIFF
--- a/Application/Dopamine.xcodeproj/project.pbxproj
+++ b/Application/Dopamine.xcodeproj/project.pbxproj
@@ -3106,7 +3106,7 @@
 					"$(PROJECT_DIR)/Dopamine/Resources",
 				);
 				MARKETING_VERSION = 3.0.5;
-				PRODUCT_BUNDLE_IDENTIFIER = com.opa334.FuckYou;
+				PRODUCT_BUNDLE_IDENTIFIER = com.opa334.Dopamine;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3144,7 +3144,7 @@
 					"$(PROJECT_DIR)/Dopamine/Resources",
 				);
 				MARKETING_VERSION = 3.0.5;
-				PRODUCT_BUNDLE_IDENTIFIER = com.opa334.FuckYou;
+				PRODUCT_BUNDLE_IDENTIFIER = com.opa334.Dopamine;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Change bundleid back to Dopamine so it doesn't require more app identifiers for e.g. users that use SideStore.