### PR TITLE
Minor improvements to DarkSword

### DIFF
--- a/Application/Dopamine/Exploits/DarkSword/DarkSword.m
+++ b/Application/Dopamine/Exploits/DarkSword/DarkSword.m
@@ -17,7 +17,6 @@
 #include <pthread.h>
 #import <IOSurface/IOSurfaceRef.h>
 #include <sys/uio.h>
-#import <xpc/xpc.h>
 #import <libjailbreak/info.h>
 #import <libjailbreak/primitives.h>
 #import <libjailbreak/primitives_external.h>

--- a/Application/Dopamine/Exploits/DarkSword/DarkSword.m
+++ b/Application/Dopamine/Exploits/DarkSword/DarkSword.m
@@ -80,17 +80,6 @@ uint64_t rwSocketPcb = 0;
 #define EARLY_KRW_LENGTH 0x20
 uint8_t controlData[EARLY_KRW_LENGTH];
 
-void setTargetKaddr(uint64_t where)
-{
-    memset(controlData, 0, EARLY_KRW_LENGTH);
-    *(uint64_t *)controlData = where;
-    int res = setsockopt(controlSocket, IPPROTO_ICMPV6, ICMP6_FILTER, controlData, EARLY_KRW_LENGTH);
-    if (res != 0) {
-        printf("[-] setsockopt failed!!!\n");
-        FAILURE(0);
-    }
-}
-
 #define TARGET_FILE_SIZE (PAGE_SIZE * 0x2)
 void *default_file_content;
 char executablePath[PATH_MAX];
@@ -310,7 +299,8 @@ void create_physically_contiguous_mapping(mach_port_t *port, mach_vm_address_t *
 
     mach_port_t memoryObject;
     kern_return_t kr = mach_make_memory_entry_64(mach_task_self(), &size, (mach_vm_address_t)physicalMappingAddress, VM_PROT_DEFAULT, &memoryObject, 0);
-    if (!surface) {
+    
+    if (kr != KERN_SUCCESS) {
         printf("[-] mach_make_memory_entry_64 failed!!!\n");
         FAILURE(0);
     }


### PR DESCRIPTION
1. Removed the `setTargetKaddr` function, a near-identical clone of the actual `set_target_kaddr` function that wasn't called anywhere in the code
2. Fixed crucial error handling oversight that checked the `surface` variable instead of checking the success of `mach_make_memory_entry_64` function like it is supposed to
3. Removed unused `xpc/xpc.h` import

These changes should generally make the code better