### PR TITLE
pe_v1: recognize own search pages instead of re-racing them as lost races

### DIFF
--- a/Application/Dopamine/Exploits/ClearSword/exploit/common.h
+++ b/Application/Dopamine/Exploits/ClearSword/exploit/common.h
@@ -88,6 +88,7 @@ typedef struct pe_context {
     int read_fd;
 
     uint64_t random_marker;
+    uint64_t random_marker_owned;
     uint64_t wired_page_marker;
 
     free_thread_shared_t* shared;

--- a/Application/Dopamine/Exploits/ClearSword/exploit/poc.c
+++ b/Application/Dopamine/Exploits/ClearSword/exploit/poc.c
@@ -120,7 +120,7 @@ kern_return_t pe_v1(void) {
 
             // place marker on start of each page
             for (uint64_t k = 0; k < search_mapping_size; k += vm_page_size) {
-                memcpy((void*)(search_mapping_address + k), &g_ctx.random_marker, sizeof(g_ctx.random_marker));
+                memcpy((void*)(search_mapping_address + k), &g_ctx.random_marker_owned, sizeof(g_ctx.random_marker_owned));
             }
 
             // save the address of the mapping onto the search mappings array
@@ -184,7 +184,9 @@ kern_return_t pe_v1(void) {
                 kr = physical_oob_read_mo(memory_object, seeking_offset, g_ctx.oob_size, g_ctx.oob_offset, read_buffer);
                 if (kr == KERN_SUCCESS) {
                     // LOG_DEBUG("Finding and corrupting socket...");
-                    if (find_and_corrupt_socket(memory_object, seeking_offset, read_buffer, write_buffer, target_inp_gencnt_list, &target_inp_gencnt_count, false) == KERN_SUCCESS) {
+                    if (*(uint64_t*)read_buffer == g_ctx.random_marker_owned) {
+                        // own search page, not a sprayed PCB; advance to next page
+                    } else if (find_and_corrupt_socket(memory_object, seeking_offset, read_buffer, write_buffer, target_inp_gencnt_list, &target_inp_gencnt_count, false) == KERN_SUCCESS) {
                         success = true;
                         break;
                     }
@@ -352,6 +354,7 @@ int clearsword_run(void) {
     g_ctx.n_of_oob_pages = 2;
 
     arc4random_buf(&g_ctx.random_marker, sizeof(g_ctx.random_marker));
+    g_ctx.random_marker_owned = g_ctx.random_marker ^ 0x9e3779b97f4a7c15ULL;  // distinct from the lost-race sentinel
     arc4random_buf(&g_ctx.wired_page_marker, sizeof(g_ctx.wired_page_marker));
 
     g_ctx.default_file_content = calloc(1, g_ctx.target_file_size);

--- a/Application/Dopamine/Exploits/DarkSword/DarkSword.m
+++ b/Application/Dopamine/Exploits/DarkSword/DarkSword.m
@@ -53,6 +53,7 @@ int highestSuccessIdx = 0;
 int successReadCount = 0;
 struct iovec iov;
 uint64_t randomMarker;
+uint64_t randomMarkerOwned;
 uint64_t wiredPageMarker;
 mach_port_t pcObject = MACH_PORT_NULL;
 mach_vm_address_t pcAddress = 0;
@@ -138,6 +139,7 @@ void init_globals(void)
     gMlockDict = [NSMutableDictionary new];
     default_file_content = calloc(1, TARGET_FILE_SIZE);
     randomMarker         = (uint64_t)arc4random() << 32 | arc4random();
+    randomMarkerOwned    = randomMarker ^ 0x9e3779b97f4a7c15ULL;  // distinct from the lost-race sentinel
     wiredPageMarker      = (uint64_t)arc4random() << 32 | arc4random();
 
     cpu_subtype_t cpusubtype = 0;
@@ -800,7 +802,7 @@ void pe_v1(void)
                 FAILURE(0);
             }
             for (int k = 0; k < searchMappingSize; k += PAGE_SIZE) {
-                *(uint64_t *)(searchMappingAddress + k) = randomMarker;
+                *(uint64_t *)(searchMappingAddress + k) = randomMarkerOwned;
             }
             [searchMappings addObject:@(searchMappingAddress)];
         }
@@ -841,7 +843,9 @@ void pe_v1(void)
             while (seekingOffset <= searchMappingSize - pcSize) {
                 kr = physical_oob_read_mo(memoryObject, seekingOffset, OOB_SIZE, OOB_OFFSET, readBuffer);
                 if (kr == KERN_SUCCESS) {
-                    if (find_and_corrupt_socket(memoryObject, seekingOffset, readBuffer, writeBuffer, targetInpGencntList, false) == KERN_SUCCESS) {
+                    if (*(uint64_t *)readBuffer == randomMarkerOwned) {
+                        // own search page, not a sprayed PCB; advance to next page
+                    } else if (find_and_corrupt_socket(memoryObject, seekingOffset, readBuffer, writeBuffer, targetInpGencntList, false) == KERN_SUCCESS) {
                         success = true;
                         break;
                     }


### PR DESCRIPTION
## Summary

`pe_v1` stamps its own search-mapping pages with `randomMarker` — the same value
`physical_oob_read_mo` uses as its lost-race sentinel. A successful OOB read that
lands on one of our own search pages therefore reads back `randomMarker`, is
judged a lost race, and is re-raced up to the retry cap before the scan skips the
page. An own page is a known, safe value that can never hold a sprayed PCB, so
that work is redundant.

This stamps the search pages with a distinct marker (`randomMarker ^ K`) so an
own-page read is recognized on the first attempt and the scan advances. The
lost-race sentinel and the physically-contiguous-mapping stamp are unchanged;
only the search-mapping stamp moves.

**This is an optimization, not a bug fix.** Acquisition behaviour is unchanged
apart from a negligible marker-collision possibility: a sprayed PCB whose first
64 bits happen to equal `randomMarkerOwned` would now be skipped by the new
branch. The scan already has the same class of collision against the lost-race
sentinel (`randomMarker`) inside `physical_oob_read_mo`; this adds one more
distinct point, so the probability of missing a real PCB goes from ~2⁻⁶⁴ to
~2⁻⁶³ — both cryptographically negligible, but not literally zero.

## Background

We stumbled on this while looking for scan-efficiency wins on A18 — where
fragmented search pools make own-page reads frequent enough to matter — but the
change stands on logical grounds for every device that runs `pe_v1`: the
own-page/sentinel collision is in the scan logic itself, independent of hardware.

## The collision

- `physical_oob_read_mo` pre-stamps the buffer/target with `randomMarker` and
  treats a read that still returns `randomMarker` as a lost race → retry
  (`if (marker != randomMarker) readRaceSucceeded = true;`).
- The search mappings are stamped with that **same** `randomMarker`.
- So a genuine OOB read landing on an own search page is indistinguishable from a
  lost race and is re-raced up to the cap.

## The change

Add `randomMarkerOwned = randomMarker ^ 0x9e3779b97f4a7c15`, stamp the search
pages with it, and recognize it in the scan loop (own page → skip). Because it
differs from `randomMarker`, `physical_oob_read_mo` returns success on the first
read of an own page instead of exhausting the retry budget.

Both kernel exploits share this scan logic, so the change touches both; no
post-exploitation path is affected:

- `Exploits/DarkSword/DarkSword.m` (arm64e)
- `Exploits/ClearSword/exploit/{common.h,poc.c}` (arm64)

## Verification (on device)

| Path | Device | Result |
| --- | --- | --- |
| ClearSword (arm64) | iPad Pro 2017 / A10X | full jailbreak succeeds — no regression |
| DarkSword (arm64e) | iPhone 15 Pro Max / A17 Pro, iOS 17.3.1 | own-page reads go from unrecognized (`own=0`) to recognized (`own>0`); acquires identically |

The DarkSword figure was measured in a separate build of the same scan code
instrumented with an own-page counter; the change here adds no logging. The size
of the saving scales with how often the scan lands on its own pages — larger on
fragmented / memory-shaped pools, negligible on standard geometry. No wall-clock
speedup is claimed on the standard path.
